### PR TITLE
Fix clippy and rustfmt errors

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - "*"
 
 jobs:
   clippy:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,0 +1,52 @@
+name: lints
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout source
+        uses: actions/checkout@v2
+
+      - name: install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
+
+      - name: run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: run cargo clippy
+        uses: actions-rs/cargo@v1
+
+  docs:
+    name: docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout source
+        uses: actions/checkout@v2
+
+      - name: install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - name: run cargo doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --all --no-deps

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: run cargo clippy
         uses: actions-rs/cargo@v1
+        with:
+          command: clippy
 
   docs:
     name: docs

--- a/src/address_space.rs
+++ b/src/address_space.rs
@@ -28,8 +28,9 @@ pub struct AddressSpace {
 // from a crate (but remember it needs to be #no_std compatible), or even write your own.
 
 impl AddressSpace {
+    #[must_use]
     pub fn new(name: &str) -> Self {
-        AddressSpace {
+        Self {
             name: name.to_string(),
             mappings: LinkedList::new(),
         }

--- a/src/address_space.rs
+++ b/src/address_space.rs
@@ -8,11 +8,11 @@ type VirtualAddress = usize;
 struct MapEntry {
     source: Arc<dyn DataSource>,
     offset: usize,
-    span:   usize,
+    span: usize,
 }
 pub struct AddressSpace {
     name: String,
-    mappings: LinkedList<MapEntry>,  // see below for comments
+    mappings: LinkedList<MapEntry>, // see below for comments
 }
 
 // comments about storing mappings
@@ -29,24 +29,40 @@ impl AddressSpace {
     pub fn new(name: &str) -> Self {
         AddressSpace {
             name: name.to_string(),
-            mappings : LinkedList::new(),
+            mappings: LinkedList::new(),
         }
     }
 
     // add a mapping from DataSource into this AddressSpace
     // return VirtualAddress, or an error
-    pub fn add_mapping(&self, source: &dyn DataSource, offset: usize, span: usize) -> Result<VirtualAddress, &str> {
+    pub fn add_mapping(
+        &self,
+        source: &dyn DataSource,
+        offset: usize,
+        span: usize,
+    ) -> Result<VirtualAddress, &str> {
         panic!("add mapping not yet implemented!");
     }
 
     // add a mapping from DataSource into this AddressSpace starting at start
     // returns Ok(), or an error if start + span doesn't have room for this mapping
-    pub fn add_mapping_at(&self, source: &dyn DataSource, offset: usize, span: usize, start: VirtualAddress) -> Result<(), &str> {
+    pub fn add_mapping_at(
+        &self,
+        source: &dyn DataSource,
+        offset: usize,
+        span: usize,
+        start: VirtualAddress,
+    ) -> Result<(), &str> {
         panic!("add mapping not yet implemented!");
     }
 
     // remove the mapping to DataSource that starts at VirtualAddress
-    pub fn remove_mapping(&self, source: &dyn DataSource, start: VirtualAddress) -> Result<(), &str> {
+    pub fn remove_mapping(
+        &self,
+        source: &dyn DataSource,
+        start: VirtualAddress,
+    ) -> Result<(), &str> {
         panic!("remove_mapping not yet implemented!");
     }
 }
+

--- a/src/address_space.rs
+++ b/src/address_space.rs
@@ -65,4 +65,3 @@ impl AddressSpace {
         panic!("remove_mapping not yet implemented!");
     }
 }
-

--- a/src/address_space.rs
+++ b/src/address_space.rs
@@ -10,6 +10,8 @@ struct MapEntry {
     offset: usize,
     span: usize,
 }
+
+/// An address space.
 pub struct AddressSpace {
     name: String,
     mappings: LinkedList<MapEntry>, // see below for comments
@@ -33,8 +35,10 @@ impl AddressSpace {
         }
     }
 
-    // add a mapping from DataSource into this AddressSpace
-    // return VirtualAddress, or an error
+    /// Add a mapping from a `DataSource` into this `AddressSpace`.
+    ///
+    /// # Errors
+    /// If the desired mapping is invalid.
     pub fn add_mapping(
         &self,
         source: &dyn DataSource,
@@ -44,8 +48,10 @@ impl AddressSpace {
         panic!("add mapping not yet implemented!");
     }
 
-    // add a mapping from DataSource into this AddressSpace starting at start
-    // returns Ok(), or an error if start + span doesn't have room for this mapping
+    /// Add a mapping from `DataSource` into this `AddressSpace` starting at a specific address.
+    ///
+    /// # Errors
+    /// If there is insufficient room subsequent to `start`.
     pub fn add_mapping_at(
         &self,
         source: &dyn DataSource,
@@ -56,7 +62,9 @@ impl AddressSpace {
         panic!("add mapping not yet implemented!");
     }
 
-    // remove the mapping to DataSource that starts at VirtualAddress
+    /// Remove the mapping to `DataSource` that starts at the given address.
+    /// # Errors
+    /// If the mapping could not be removed.
     pub fn remove_mapping(
         &self,
         source: &dyn DataSource,

--- a/src/address_space.rs
+++ b/src/address_space.rs
@@ -46,7 +46,7 @@ impl AddressSpace {
         offset: usize,
         span: usize,
     ) -> Result<VirtualAddress, &str> {
-        panic!("add mapping not yet implemented!");
+        todo!()
     }
 
     /// Add a mapping from `DataSource` into this `AddressSpace` starting at a specific address.
@@ -60,7 +60,7 @@ impl AddressSpace {
         span: usize,
         start: VirtualAddress,
     ) -> Result<(), &str> {
-        panic!("add mapping not yet implemented!");
+        todo!()
     }
 
     /// Remove the mapping to `DataSource` that starts at the given address.
@@ -71,6 +71,6 @@ impl AddressSpace {
         source: &dyn DataSource,
         start: VirtualAddress,
     ) -> Result<(), &str> {
-        panic!("remove_mapping not yet implemented!");
+        todo!()
     }
 }

--- a/src/cacher.rs
+++ b/src/cacher.rs
@@ -1,4 +1,3 @@
-
 // This is the one that needs the most design.
 // It coordinates allocating physical pages to cache data from DataSources
 // It asks DataSources to fetch data, in response to a page fault, and when in arrives, it adds

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -31,6 +31,7 @@ pub enum Flags {
     Shared,
 }
 
+#[allow(clippy::module_name_repetitions)]
 pub struct FileDataSource {
     file_handle: File,
     name: String,

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -39,14 +39,12 @@ pub struct FileDataSource {
 
 impl FileDataSource {
     pub fn new(name: &str) -> Result<Self, &str> {
-        if let Ok(f) = File::open(name) {
-            Ok(FileDataSource {
-                file_handle: f,
+        File::open(name).map_or(Err("couldn't open {name}"), |file_handle| {
+            Ok(Self {
+                file_handle,
                 name: name.to_string(),
             })
-        } else {
-            Err("couldn't open {name}")
-        }
+        })
     }
 }
 

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -38,6 +38,10 @@ pub struct FileDataSource {
 }
 
 impl FileDataSource {
+    /// Create a new `FileDataSource`.
+    ///
+    /// # Errors
+    /// If the file can't be opened.
     pub fn new(name: &str) -> Result<Self, &str> {
         File::open(name).map_or(Err("couldn't open {name}"), |file_handle| {
             Ok(Self {

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -3,11 +3,22 @@ use std::fs::File;
 
 pub trait DataSource {
     // constructors are left to each implementation, once you have one, you can:
-    fn read(&self, offset: usize, length: usize, buffer: &mut Vec<u8> ) -> Result<(), &str>;
-    fn write(&self, offset: usize, length: usize, buffer: &mut Vec<u8> ) -> Result<(), &str>;
+    fn read(&self, offset: usize, length: usize, buffer: &mut Vec<u8>) -> Result<(), &str>;
+    fn write(&self, offset: usize, length: usize, buffer: &mut Vec<u8>) -> Result<(), &str>;
     fn flush(&self, offset: usize, length: usize) -> Result<(), &str>;
-    fn add_map(&self, with_flag: Flags, into_address_space: &mut AddressSpace, offset: usize, length: usize) -> Result<usize, &str>;
-    fn del_map(&self, from_address_space: &mut AddressSpace, offset: usize, length: usize) -> Result<(), &str>;
+    fn add_map(
+        &self,
+        with_flag: Flags,
+        into_address_space: &mut AddressSpace,
+        offset: usize,
+        length: usize,
+    ) -> Result<usize, &str>;
+    fn del_map(
+        &self,
+        from_address_space: &mut AddressSpace,
+        offset: usize,
+        length: usize,
+    ) -> Result<(), &str>;
 }
 
 enum Flags {
@@ -17,7 +28,7 @@ enum Flags {
     execute,
     copy_on_write,
     private,
-    shared
+    shared,
 }
 
 pub struct FileDataSource {
@@ -27,7 +38,7 @@ pub struct FileDataSource {
 
 impl FileDataSource {
     pub fn new(name: &str) -> Result<Self, &str> {
-        if let Ok(f) = File::open(name){
+        if let Ok(f) = File::open(name) {
             Ok(FileDataSource {
                 file_handle: f,
                 name: name.to_string(),
@@ -39,19 +50,30 @@ impl FileDataSource {
 }
 
 impl DataSource for FileDataSource {
-    fn read(&self, offset: usize, length: usize, buffer: &mut Vec<u8> ) -> Result<(), &str> {
+    fn read(&self, offset: usize, length: usize, buffer: &mut Vec<u8>) -> Result<(), &str> {
         panic!("not yet done");
     }
-    fn write(&self, offset: usize, length: usize, buffer: &mut Vec<u8> ) -> Result<(), &str>{
+    fn write(&self, offset: usize, length: usize, buffer: &mut Vec<u8>) -> Result<(), &str> {
         panic!("not yet done");
     }
-    fn flush(&self, offset: usize, length: usize) -> Result<(), &str>{
+    fn flush(&self, offset: usize, length: usize) -> Result<(), &str> {
         panic!("not yet done");
     }
-    fn add_map(&self, with_flag: Flags, into_address_space: &mut AddressSpace, offset: usize, length: usize) -> Result<usize, &str>{
+    fn add_map(
+        &self,
+        with_flag: Flags,
+        into_address_space: &mut AddressSpace,
+        offset: usize,
+        length: usize,
+    ) -> Result<usize, &str> {
         panic!("not yet done");
     }
-    fn del_map(&self, from_address_space: &mut AddressSpace, offset: usize, length: usize) -> Result<(), &str>{
+    fn del_map(
+        &self,
+        from_address_space: &mut AddressSpace,
+        offset: usize,
+        length: usize,
+    ) -> Result<(), &str> {
         panic!("not yet done");
     }
 }

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -21,7 +21,7 @@ pub trait DataSource {
     ) -> Result<(), &str>;
 }
 
-enum Flags {
+pub enum Flags {
     // TODO: do we need more flags?
     Read,
     Write,

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -23,12 +23,12 @@ pub trait DataSource {
 
 enum Flags {
     // TODO: do we need more flags?
-    read,
-    write,
-    execute,
-    copy_on_write,
-    private,
-    shared,
+    Read,
+    Write,
+    Execute,
+    CopyOnWrite,
+    Private,
+    Shared,
 }
 
 pub struct FileDataSource {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@ mod address_space;
 mod cacher;
 mod data_source;
 
-use address_space::AddressSpace;
-use data_source::FileDataSource;
+pub use address_space::AddressSpace;
+pub use data_source::FileDataSource;
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
-
 mod address_space;
-mod data_source;
 mod cacher;
+mod data_source;
 
 use address_space::AddressSpace;
 use data_source::FileDataSource;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_variables)]
+
 mod address_space;
 mod cacher;
 mod data_source;


### PR DESCRIPTION
This is a chore PR to conform the codebase to `clippy` and `rustfmt`. I've made
it conformant in as frictionless a way as possible.

- Format code with `rustfmt`.
- Add basic CI.
- Fix enum variant capitalization.
- Make library re-exports public.
- Don't leak private types in APIs. `Flags` was previously private, but exposed
    in the public `DataSource` API.
- Allow module name repetitions for `FileDataSource`. It's possible we'll want
    to change the name of this object later, but this is the lowest-friction
    change.
- Clean up `FileDataSource::new`. It's more idiomatic to use provided methods on
    `Option` and `Result` than re-implenting the methods with `match` or `if
    let`.
- Make doc comments rustdoc-compatible. (Try running `cargo doc --open`!)
- Add must_use annotation to constructors. Any non-side-effecting function
    should always have this annotation.
- Use `todo` to panic at todo code sites. This is more idiomatic than writing a
    custom panic message.
