### PR TITLE
Remove manual panics

### DIFF
--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -54,13 +54,13 @@ impl FileDataSource {
 
 impl DataSource for FileDataSource {
     fn read(&self, offset: usize, length: usize, buffer: &mut Vec<u8>) -> Result<(), &str> {
-        panic!("not yet done");
+        todo!()
     }
     fn write(&self, offset: usize, length: usize, buffer: &mut Vec<u8>) -> Result<(), &str> {
-        panic!("not yet done");
+        todo!()
     }
     fn flush(&self, offset: usize, length: usize) -> Result<(), &str> {
-        panic!("not yet done");
+        todo!()
     }
     fn add_map(
         &self,
@@ -69,7 +69,7 @@ impl DataSource for FileDataSource {
         offset: usize,
         length: usize,
     ) -> Result<usize, &str> {
-        panic!("not yet done");
+        todo!()
     }
     fn del_map(
         &self,
@@ -77,6 +77,6 @@ impl DataSource for FileDataSource {
         offset: usize,
         length: usize,
     ) -> Result<(), &str> {
-        panic!("not yet done");
+        todo!()
     }
 }


### PR DESCRIPTION
It's more idiomatic to use `todo` instead of writing a by-hand panic
message which says the same thing. I missed this in my last cleanup
patch.
