### PR TITLE
Add addr attribute to MapEntry

### DIFF
--- a/src/address_space.rs
+++ b/src/address_space.rs
@@ -9,6 +9,7 @@ struct MapEntry {
     source: Arc<dyn DataSource>,
     offset: usize,
     span: usize,
+    addr: usize,
 }
 
 /// An address space.


### PR DESCRIPTION
Adding an `addr` attribute to the `MapEntry` struct so we know where in the address space this mapping begins.