### PR TITLE
Fix rustformat error

### DIFF
--- a/src/address_space.rs
+++ b/src/address_space.rs
@@ -79,14 +79,14 @@ impl AddressSpace {
 
     /// Look up the DataSource and offset within that DataSource for a
     /// VirtualAddress / AccessType in this AddressSpace
-    /// 
+    ///
     /// # Errors
     /// If this VirtualAddress does not have a valid mapping in &self,
     /// or if this AccessType is not permitted by the mapping
     pub fn get_source_for_addr<D: DataSource>(
         &self,
         addr: VirtualAddress,
-        access_type: FlagBuilder
+        access_type: FlagBuilder,
     ) -> Result<(&D, usize), &str> {
         todo!();
     }
@@ -218,4 +218,3 @@ impl FlagBuilder {
         }
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,9 @@ mod tests {
         let offset: usize = 0;
         let length: usize = 1;
 
-        let addr = addr_space.add_mapping(&data_source, offset, length).unwrap();
+        let addr = addr_space
+            .add_mapping(&data_source, offset, length)
+            .unwrap();
         assert!(addr != 0);
 
         // we should move these tests into addr_space, since they access non-public internals of the structure:


### PR DESCRIPTION
This just fixes a linter error caused by nonconformance with rustfmt.

Remember to try to run CI in a PR before pushing to main!
